### PR TITLE
refactor: (Hangfire): reestructure, add variables in appsettings

### DIFF
--- a/PoliedroHangFire/HangfireJobs/ConfigJbos/Billing/ConfigJobs.cs
+++ b/PoliedroHangFire/HangfireJobs/ConfigJbos/Billing/ConfigJobs.cs
@@ -2,36 +2,35 @@
 using PoliedroHangFire.Application.ClientBilling.Interfaces;
 using PoliedroHangFire.Application.PendingInvoicesBilling.Interfaces;
 
-namespace PoliedroHangFire.HangfireJobs.ConfigJbos.Billing
+namespace PoliedroHangFire.HangfireJobs.ConfigJbos.Billing;
+
+public class ConfigJobs
 {
-    public class ConfigJobs
+    public static async Task RegisterJobsAsync(IServiceProvider services)
     {
-        public static async Task RegisterJobsAsync(IServiceProvider services)
+        var recurringJobs = services.GetRequiredService<IRecurringJobManager>();
+        var clientService = services.GetRequiredService<IClientService>();
+        var job = services.GetRequiredService<IPendingInvoicesBilling>();
+
+        var clientes = await clientService.GetClientBillingsAsync();
+
+        foreach (var cliente in clientes)
         {
-            var recurringJobs = services.GetRequiredService<IRecurringJobManager>();
-            var clientService = services.GetRequiredService<IClientService>();
-            var job = services.GetRequiredService<IPendingInvoicesBilling>();
+            if (!cliente.Active || cliente.Iterations <= 0) continue;
 
-            var clientes = await clientService.GetClientBillingsAsync();
+            var jobId = $"facturacion-cliente-{cliente.ClientBillingElectronicId}";
+            var interval = Cron.MinuteInterval(cliente.Iterations);
 
-            foreach (var cliente in clientes)
-            {
-                if (!cliente.Active || cliente.Iterations <= 0) continue;
-
-                var jobId = $"facturacion-cliente-{cliente.ClientBillingElectronicId}";
-                var interval = Cron.MinuteInterval(cliente.Iterations);
-
-                recurringJobs.AddOrUpdate(
-                    jobId,
-                    () => job.InvoicePendingAsync(
-                        cliente.ClientBillingElectronicId,
-                        cliente.ApiKey,
-                        cliente.ResolutionType,
-                        cliente.Name
-                    ),
-                    interval
-                );
-            }
+            recurringJobs.AddOrUpdate(
+                jobId,
+                () => job.InvoicePendingAsync(
+                    cliente.ClientBillingElectronicId,
+                    cliente.ApiKey,
+                    cliente.ResolutionType,
+                    cliente.Name
+                ),
+                interval
+            );
         }
     }
 }

--- a/PoliedroHangFire/Infrastructure/External/Billing/Adapters/ClientBilling/ClientService.cs
+++ b/PoliedroHangFire/Infrastructure/External/Billing/Adapters/ClientBilling/ClientService.cs
@@ -3,36 +3,17 @@ using System.Text.Json;
 
 namespace PoliedroHangFire.Infrastructure.External.Billing.Adapters.ClientBilling;
 
-public class ClientService : IClientService
+public class ClientService(HttpClient httpClient, IConfiguration config) : IClientService
 {
-    private readonly HttpClient _httpClient;
-    private readonly IConfiguration _configuration;
-
-    public ClientService(HttpClient httpClient, IConfiguration configuration)
-    {
-        _httpClient = httpClient;
-        _configuration = configuration;
-    }
-
     public async Task<List<Domain.ClientBilling.Entities.ClientBilling>> GetClientBillingsAsync()
     {
-        var useMock = _configuration.GetValue<bool>("ClientBilling:UseMock");
-
-        if (useMock)
-        {
-            return new List<Domain.ClientBilling.Entities.ClientBilling>(); // Datos simulados
-        }
-
-        _httpClient.DefaultRequestHeaders.Add("X-Environment", "staging-billing");
-
-        var response = await _httpClient.GetAsync("https://wc9oqtphb5.execute-api.us-east-2.amazonaws.com/billing/api/v1/client");
+        httpClient.DefaultRequestHeaders.Add("X-Environment", "production-billing");
+        var response = await httpClient.GetAsync(config["External:ClientsUrl"]);
         response.EnsureSuccessStatusCode();
-
         var content = await response.Content.ReadAsStringAsync();
-
         return JsonSerializer.Deserialize<List<Domain.ClientBilling.Entities.ClientBilling>>(content, new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true
-        }) ?? new();
+        }) ?? [];
     }
 }

--- a/PoliedroHangFire/Infrastructure/External/Billing/Adapters/PendingInvoicesBilling/PendingInvoicesService.cs
+++ b/PoliedroHangFire/Infrastructure/External/Billing/Adapters/PendingInvoicesBilling/PendingInvoicesService.cs
@@ -4,21 +4,19 @@ using System.Text.Json;
 
 namespace PoliedroHangFire.Infrastructure.External.Billing.Adapters.PendingInvoicesBilling;
 
-public class PendingInvoicesService(HttpClient httpClient) : IPendingInvoicesBilling
+public class PendingInvoicesService(HttpClient httpClient, IConfiguration config) : IPendingInvoicesBilling
 {
-    private readonly HttpClient _httpClient = httpClient;
-
     public async Task InvoicePendingAsync(int clienteId, string token, bool resolutionType, string name)
     {
-        _httpClient.DefaultRequestHeaders.Add("X-Environment", "staging-billing");
-        var request = new HttpRequestMessage(HttpMethod.Get, $"https://wc9oqtphb5.execute-api.us-east-2.amazonaws.com/billing/api/v1/invoicespendingwithdetails");
+        httpClient.DefaultRequestHeaders.Add("X-Environment", "production-billing");
+        var request = new HttpRequestMessage(HttpMethod.Get, config["External:PendingInvoicesUrl"]);
         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
         request.Content = new StringContent(JsonSerializer.Serialize(new
         {
             ResolutionType = resolutionType,
             Name = name
         }), Encoding.UTF8, "application/json");
-        var response = await _httpClient.SendAsync(request);
+        var response = await httpClient.SendAsync(request);
         response.EnsureSuccessStatusCode();
     }
 }

--- a/PoliedroHangFire/PoliedroHangFire.csproj
+++ b/PoliedroHangFire/PoliedroHangFire.csproj
@@ -10,6 +10,17 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <Compile Remove="Infrastructure\Persistence\**" />
+	  <Compile Remove="Infrastructure\Resource\**" />
+	  <Content Remove="Infrastructure\Persistence\**" />
+	  <Content Remove="Infrastructure\Resource\**" />
+	  <EmbeddedResource Remove="Infrastructure\Persistence\**" />
+	  <EmbeddedResource Remove="Infrastructure\Resource\**" />
+	  <None Remove="Infrastructure\Persistence\**" />
+	  <None Remove="Infrastructure\Resource\**" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<Content Update="appsettings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
@@ -32,8 +43,6 @@
 		<Folder Include="Application\ClientBilling\Services\" />
 		<Folder Include="Application\PendingInvoicesBilling\DTOs\" />
 		<Folder Include="Application\PendingInvoicesBilling\Services\" />
-		<Folder Include="Infrastructure\Resource\" />
-		<Folder Include="Infrastructure\Persistence\" />
 	</ItemGroup>
 
 </Project>

--- a/PoliedroHangFire/WebApi/Program.cs
+++ b/PoliedroHangFire/WebApi/Program.cs
@@ -6,7 +6,6 @@ using PoliedroHangFire.Application.PendingInvoicesBilling.Interfaces;
 using PoliedroHangFire.HangfireJobs.ConfigJbos.Billing;
 using PoliedroHangFire.Infrastructure.External.Billing.Adapters.ClientBilling;
 using PoliedroHangFire.Infrastructure.External.Billing.Adapters.PendingInvoicesBilling;
-using PoliedroHangFire.WebApi;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/PoliedroHangFire/appsettings.json
+++ b/PoliedroHangFire/appsettings.json
@@ -6,10 +6,11 @@
     }
   },
   "AllowedHosts": "*",
-    "ConnectionStrings": {
-        "HangfireConnection": "Server=poliedro-cluster-mysql-u44828.vm.elestio.app;Port=24306;Database=hangfire_billing;Uid=root;Pwd=TkZNPId9-p1i5-KQPULxOK;Allow User Variables=True;"
-    },
-     "ClientBilling": {
-    "UseMock": true
+  "ConnectionStrings": {
+    "HangfireConnection": "Server=poliedro-cluster-mysql-u44828.vm.elestio.app;Port=24306;Database=hangfire_billing;Uid=root;Pwd=TkZNPId9-p1i5-KQPULxOK;Allow User Variables=True;"
+  },
+  "External": {
+    "ClientsUrl": "https://wc9oqtphb5.execute-api.us-east-2.amazonaws.com/billing/api/v1/client",
+    "PendingInvoicesUrl": "https://wc9oqtphb5.execute-api.us-east-2.amazonaws.com/billing/api/v1/invoicespendingwithdetails"
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor Hangfire job setup and HTTP client services to adopt file-scoped namespaces, inject configuration, externalize service endpoints, remove mock paths, and tidy up the appsettings and code imports

Enhancements:
- Restructure job configuration to use file-scoped namespaces and clean up class formatting
- Inject IConfiguration into ClientService and PendingInvoicesService for dynamic endpoint configuration
- Externalize API URLs and environment headers into appsettings.json under an External section
- Remove mock logic from client billing service and replace hardcoded staging endpoints with production-billing settings
- Clean up unused using directives in Program.cs