### PR TITLE
feat(health) : add endpoint client health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
+# Instalar curl para el health check
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 # This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
@@ -26,4 +29,9 @@ RUN dotnet publish "PoliedroHangFire.csproj" -c $BUILD_CONFIGURATION -o /app/pub
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+
+# Agregar health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+  CMD curl -f http://localhost:8080/health/simple || exit 1
+
 ENTRYPOINT ["dotnet", "PoliedroHangFire.dll"]

--- a/PoliedroHangFire/Infrastructure/External/Billing/Adapters/InvoicesEmitterBilling/InvoicesEmitterBilling.cs
+++ b/PoliedroHangFire/Infrastructure/External/Billing/Adapters/InvoicesEmitterBilling/InvoicesEmitterBilling.cs
@@ -8,7 +8,7 @@ public class InvoicesEmitterBilling(HttpClient httpClient, IConfiguration config
     public async Task InvoicesEmitterServicesAsync(string jsonInvoices, string token)
     {
         httpClient.DefaultRequestHeaders.Clear();
-        //httpClient.DefaultRequestHeaders.Add("X-Environment", "production-billing");
+        httpClient.DefaultRequestHeaders.Add("X-Environment", "production-billing");
         var request = new HttpRequestMessage(HttpMethod.Post, config["External:EmitInvoicesUrl"]);
         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
         request.Content = new StringContent(jsonInvoices, Encoding.UTF8, "application/json");

--- a/PoliedroHangFire/PoliedroHangFire.csproj
+++ b/PoliedroHangFire/PoliedroHangFire.csproj
@@ -34,6 +34,7 @@
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1.1" />
 		<PackageReference Include="Hangfire.MySql.Core_MySql.Data" Version="2.1.10" />
 		<PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="MySql.Data" Version="9.3.0" />
 	</ItemGroup>

--- a/PoliedroHangFire/WebApi/HealthChecks/ExternalServiceHealthCheck.cs
+++ b/PoliedroHangFire/WebApi/HealthChecks/ExternalServiceHealthCheck.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace PoliedroHangFire.WebApi.HealthChecks;
+
+public class ExternalServiceHealthCheck : IHealthCheck
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly string _url;
+    private readonly string _serviceName;
+
+    public ExternalServiceHealthCheck(IHttpClientFactory httpClientFactory, string url, string serviceName)
+    {
+        _httpClientFactory = httpClientFactory;
+        _url = url;
+        _serviceName = serviceName;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var httpClient = _httpClientFactory.CreateClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(10);
+            httpClient.DefaultRequestHeaders.Clear();
+            httpClient.DefaultRequestHeaders.Add("X-Environment", "production-billing");
+            
+            using var response = await httpClient.GetAsync(_url, cancellationToken);
+            
+            if (response.IsSuccessStatusCode)
+            {
+                return HealthCheckResult.Healthy($"{_serviceName} is available. Status: {response.StatusCode}");
+            }
+            else
+            {
+                return HealthCheckResult.Degraded($"{_serviceName} returned {response.StatusCode}");
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            return HealthCheckResult.Unhealthy($"{_serviceName} is unavailable", ex);
+        }
+        catch (TaskCanceledException ex)
+        {
+            return HealthCheckResult.Unhealthy($"{_serviceName} timeout", ex);
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy($"{_serviceName} check failed", ex);
+        }
+    }
+}

--- a/PoliedroHangFire/WebApi/Program.cs
+++ b/PoliedroHangFire/WebApi/Program.cs
@@ -8,6 +8,7 @@ using PoliedroHangFire.HangfireJobs.ConfigJbos.Billing;
 using PoliedroHangFire.Infrastructure.External.Billing.Adapters.ClientBilling;
 using PoliedroHangFire.Infrastructure.External.Billing.Adapters.InvoicesEmitterBilling;
 using PoliedroHangFire.Infrastructure.External.Billing.Adapters.PendingInvoicesBilling;
+using PoliedroHangFire.WebApi.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +16,15 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHttpClient<IClientService, ClientService>();
 builder.Services.AddTransient<IPendingInvoicesBilling, PendingInvoicesService>();
 builder.Services.AddTransient<IInvoicesEmitterBIlling, InvoicesEmitterBilling>();
+
+// Agregar Health Check solo para el servicio de clientes
+builder.Services.AddHealthChecks()
+    .AddTypeActivatedCheck<ExternalServiceHealthCheck>(
+        "client-service",
+        args: new object[] { builder.Configuration["External:ClientsUrl"]!, "Client Service" });
+
+// Registrar HttpClient para health checks
+builder.Services.AddHttpClient();
 
 builder.Services.AddHangfire(config => {
     var connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? builder.Configuration.GetConnectionString("HangfireConnection");
@@ -35,6 +45,31 @@ builder.Services.AddAntiforgery();
 
 var app = builder.Build();
 
+// Configurar Health Check endpoints
+app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+{
+    ResponseWriter = async (context, report) =>
+    {
+        context.Response.ContentType = "application/json";
+        var response = new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.Select(x => new
+            {
+                name = x.Key,
+                status = x.Value.Status.ToString(),
+                description = x.Value.Description,
+                duration = x.Value.Duration.TotalMilliseconds
+            }),
+            totalDuration = report.TotalDuration.TotalMilliseconds
+        };
+        await context.Response.WriteAsync(System.Text.Json.JsonSerializer.Serialize(response));
+    }
+});
+
+// Health check simple (para Docker)
+app.MapHealthChecks("/health/simple");
+
 app.UseHangfireDashboard("/hangfire", new DashboardOptions
 {
     Authorization = new IDashboardAuthorizationFilter[]
@@ -42,9 +77,20 @@ app.UseHangfireDashboard("/hangfire", new DashboardOptions
         new PoliedroHangFire.WebApi.DevDashboardAccessFilter()
     }
 });
-using (var scope = app.Services.CreateScope())
+
+// Intentar registrar jobs de forma segura
+try
 {
-    await ConfigJobs.RegisterJobsAsync(scope.ServiceProvider);
+    using (var scope = app.Services.CreateScope())
+    {
+        await ConfigJobs.RegisterJobsAsync(scope.ServiceProvider);
+        Console.WriteLine("[INFO] Jobs registrados exitosamente durante el startup");
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"[WARNING] No se pudieron registrar los jobs durante el startup: {ex.Message}");
+    Console.WriteLine("[INFO] La aplicación continuará ejecutándose. Verifique la conectividad con el servicio externo.");
 }
 
 app.Run();

--- a/PoliedroHangFire/appsettings.json
+++ b/PoliedroHangFire/appsettings.json
@@ -10,8 +10,8 @@
     "HangfireConnection": "Server=poliedro-cluster-mysql-u44828.vm.elestio.app;Port=24306;Database=hangfire_billing_qa;Uid=root;Pwd=TkZNPId9-p1i5-KQPULxOK;Allow User Variables=True;"
   },
   "External": {
-    "ClientsUrl": "http://localhost:5062/api/v1/client",
-    "PendingInvoicesUrl": "http://localhost:5062/api/v1/invoicespendingwithdetails",
-    "EmitInvoicesUrl": "http://localhost:5062/api/v1/billing"
+    "ClientsUrl": "https://wc9oqtphb5.execute-api.us-east-2.amazonaws.com/billing/api/v1/client",
+    "PendingInvoicesUrl": "https://wc9oqtphb5.execute-api.us-east-2.amazonaws.com/billing/api/v1/invoicespendingwithdetails",
+    "EmitInvoicesUrl": "https://wc9oqtphb5.execute-api.us-east-2.amazonaws.com/billing/api/v1/billing"
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a health check mechanism for the external client service with new endpoints, Docker HEALTHCHECK configuration, and improve startup resilience by handling job registration failures gracefully.

New Features:
- Add ExternalServiceHealthCheck implementation for monitoring the client service
- Register detailed (/health) and simple (/health/simple) health check endpoints
- Install curl in Docker image and configure a HEALTHCHECK invoking /health/simple

Enhancements:
- Register HttpClientFactory and add a named health check for the client-service URL
- Wrap Hangfire job registration in startup within try/catch to log warnings and continue on failures
- Update External service URLs in appsettings.json to production endpoints