### PR TITLE
refactor(hangfire): move Hangfire storage to dedicated MySQL instance

### DIFF
--- a/.idea/.idea.PoliedroHangFire/.idea/.gitignore
+++ b/.idea/.idea.PoliedroHangFire/.idea/.gitignore
@@ -1,0 +1,15 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/.idea.PoliedroHangFire.iml
+/contentModel.xml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.PoliedroHangFire/.idea/.name
+++ b/.idea/.idea.PoliedroHangFire/.idea/.name
@@ -1,0 +1,1 @@
+PoliedroHangFire

--- a/.idea/.idea.PoliedroHangFire/.idea/encodings.xml
+++ b/.idea/.idea.PoliedroHangFire/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.PoliedroHangFire/.idea/indexLayout.xml
+++ b/.idea/.idea.PoliedroHangFire/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.PoliedroHangFire/.idea/vcs.xml
+++ b/.idea/.idea.PoliedroHangFire/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,88 +1,97 @@
 # AGENTS.md
 
-## Project identity
+## Project
 
-- .NET 10 ASP.NET Core Web App for Poliedro billing automation via Hangfire.
-- Single project at `PoliedroHangFire/`, solution file at `PoliedroHangFire.sln`.
+.NET 10 ASP.NET Core Hangfire service for electronic invoice automation (Poliedro). Single-project solution (no test project).
 
-## Build, test, run
+## Commands
 
 ```bash
-dotnet restore
-dotnet build
-dotnet test
+dotnet restore              # restore packages
+dotnet build                # compile
+dotnet run --project PoliedroHangFire   # run locally (ports 5254 / 7008)
 ```
 
-No test projects exist yet — CI runs `dotnet test` expecting `[Fact]`/`[Test]` attributes somewhere.
+No tests, linter, formatter, or typecheck commands exist.
 
-Run locally: `dotnet run --project PoliedroHangFire` (listens on `http://localhost:5254` and `https://localhost:7008`).
+## Architecture (single `.csproj`)
 
-## Excluded from compilation
+| Layer | Path | Role |
+|---|---|---|
+| Domain | `Domain/ClientBilling/Entities/` | Entity models (`ClientBilling`) |
+| Application | `Application/*/Interfaces/` | Service interfaces |
+| Infrastructure | `Infrastructure/External/` | HTTP adapters to external billing APIs |
+| Infrastructure | `Infrastructure/Observability/` | Prometheus metrics (`HangfireMetrics`) |
+| WebApi | `WebApi/` | `Program.cs`, health checks, Hangfire dashboard filter |
+| HangfireJobs | `HangfireJobs/ConfigJbos/` | Recurring job registration |
 
-The `.csproj` explicitly removes these folders from compile, content, and resource inclusion:
-- `Infrastructure\Persistence\**`
-- `Infrastructure\Resource\**`
+**Important**: `Infrastructure/Persistence/` and `Infrastructure/Resource/` are **excluded from compilation** (csproj `Remove` directives).
 
-Do NOT place code in those directories.
+## Hangfire
 
-## Hangfire configuration
+- **Storage**: MySQL via `MySqlStorage` with `TablesPrefix = "Hangfire"`
+- **Worker count**: 5
+- **Connection string**: `MYSQL_CONNECTION` env var > `ConnectionStrings:HangfireConnection` in appsettings.json
+- **Dashboard**: `/hangfire` — **no auth** (`DevDashboardAccessFilter` always returns `true`)
+- **Job registration**: At startup, `ConfigJobs.RegisterJobsAsync` fetches clients from `External:ClientsUrl` and registers one recurring job per client: `facturacion-cliente-{id}` at `Cron.MinuteInterval(iterations)`.
 
-- **Storage**: `MySqlStorage` with table prefix `Hangfire`.
-- **Connection string override**: Set `MYSQL_CONNECTION` env var to override `ConnectionStrings:HangfireConnection`. The start-up reads the env var first, falls back to `appsettings.json`.
-- **Server**: `AddHangfireServer(options => options.WorkerCount = 5)`.
-- **Dashboard**: mounted at `/hangfire`. No auth (the `DevDashboardAccessFilter` always returns `true`).
-- `Hangfire.MemoryStorage` is in the dependencies but NOT used at runtime — it's only referenced in the package list.
+**Connection string must include** `Pooling=True;Max Pool Size=200;Connection Lifetime=300;Connection Idle Timeout=60;` to avoid pool exhaustion. If using `MYSQL_CONNECTION` env var, add these parameters there too. For local Docker setup, also add `Connection Timeout=5;Default Command Timeout=60;`.
 
-## Job registration flow (critical)
+**Job flow**: Recurring job (`PendingInvoicesService.InvoicePendingAsync`) → checks pending invoices → enqueues `BackgroundJob.Enqueue<IInvoicesEmitterBIlling>` to emit.
 
-1. On startup, `ConfigJobs.RegisterJobsAsync` is called.
-2. It calls `IClientService.GetClientBillingsAsync()` to fetch clients from the external billing API.
-3. For each client, a **recurring Hangfire job** is registered with id `facturacion-cliente-{ClientBillingElectronicId}` running at `Cron.MinuteInterval(cliente.Iterations)` minutes.
-4. Each recurring job calls `IPendingInvoicesBilling.InvoicePendingAsync(...)`.
-5. If pending invoices are found, it enqueues a fire-and-forget job via `BackgroundJob.Enqueue<IInvoicesEmitterBIlling>(...)`.
+## External APIs (config key `External:*`)
 
-**Important**: Jobs are not static — they are created dynamically from API data. If `GetClientBillingsAsync` fails, jobs are NOT registered but the app continues running (catch in Program.cs).
+| Config | Purpose |
+|---|---|
+| `ClientsUrl` | GET list of clients |
+| `PendingInvoicesUrl` | GET pending invoices (Bearer token auth) |
+| `EmitInvoicesUrl` | POST to emit invoices |
 
-## Health checks
+All HTTP calls include header `X-Environment: production-billing`.
 
-- `/health` — detailed JSON with per-check status, handled by custom response writer (Program.cs:49).
-- `/health/simple` — raw minimal response, used by Docker HEALTHCHECK.
-- Both require `AddHealthChecks()` and `MapHealthChecks()`, which are wired in Program.cs.
+## Endpoints
 
-## Docker
+| Route | Description |
+|---|---|
+| `/hangfire` | Hangfire dashboard (no auth) |
+| `/health` | Detailed JSON health check |
+| `/health/simple` | Simple health check (used by Docker `HEALTHCHECK`) |
+| `/metrics` | Prometheus metrics (prometheus-net) |
 
-- **Build context**: repository root (not `PoliedroHangFire/`).
-- **Target framework**: `net10.0`, base image `mcr.microsoft.com/dotnet/aspnet:10.0`.
-- **Exposed ports**: 8080, 8081.
-- **Healthcheck**: `curl -f http://localhost:8080/health/simple`.
+## Prometheus metrics
+
+Defined in `HangfireMetrics` (singleton, wired in DI). Exposes counters (`billing_jobs_executed_total`, `billing_emit_errors_total`, etc.), gauges, and histograms for job duration. HTTP metrics middleware (`UseHttpMetrics`) is enabled.
 
 ## CI/CD (GitHub Actions)
 
-- **Workflow**: `.github/workflows/aws.yml`.
-- **Triggers**: push to `Feature/test-github-actions`; PRs (opened, sync, reopen, close) to `main`, `release/*`, `releasecandidate/*`.
-- **Jobs**: `dotnet` (restore, build, test) → `sonar` (SonarCloud) → on merge: `docker` (push to AWS ECR), `docker-hub` (push to Docker Hub), `deploy` (AWS ECS force-new-deployment).
-- Docker and deploy only run when `github.event.pull_request.merged == true`.
+`.github/workflows/aws.yml` — triggers on PR merge to `main`, `release/*`, `releasecandidate/*`:
 
-## External API dependencies
+1. `dotnet restore` + `dotnet build --configuration Release`
+2. `dotnet test --configuration Release --no-build`
+3. SonarCloud scan
+4. Docker build → push to ECR + Docker Hub
+5. Deploy to AWS ECS (`update-service --force-new-deployment`)
 
-All external URLs are configured in `appsettings.json` under `External`:
-- `ClientsUrl` — fetch client list
-- `PendingInvoicesUrl` — get pending invoices per client
-- `EmitInvoicesUrl` — post invoices for emission
+## Docker
 
-All HTTP clients send header `X-Environment: production-billing`.
+Multi-stage build (container port `8080`). `HEALTHCHECK` runs `curl -f http://localhost:8080/health/simple`.
 
-## Project structure conventions
+### Docker Compose (local development)
 
-- `Domain/` — entities (e.g., `ClientBilling`)
-- `Application/{Feature}/Interfaces/` — service interfaces
-- `Application/{Feature}/DTOs/` — empty, reserved
-- `Application/{Feature}/Services/` — empty, reserved
-- `Infrastructure/External/Billing/Adapters/{Feature}/` — service implementations
-- `HangfireJobs/ConfigJbos/Billing/` — job scheduling
-- `WebApi/` — Program.cs, filters, health checks
+`docker-compose.yml` at repo root runs MySQL 8.0 (`hangfire-mysql`) + Hangfire (`hangfire-app`). The `MYSQL_CONNECTION` env var points to the local MySQL container. Tables are auto-created by `PrepareSchemaIfNecessary=true`.
 
-## Security notes
+```bash
+docker compose up -d --build
+# App at http://localhost:8080
+# MySQL at localhost:3307 (exposed for admin tools)
+```
 
-- `appsettings.json` contains a hardcoded MySQL password. Do not log this file or expose it.
-- The Hangfire dashboard has no auth (open to anyone who reaches the endpoint).
+**Warning**: First-time startup requires MySQL to initialize (~30s). Hangfire waits via `depends_on: condition: service_healthy`. Check logs with `docker compose logs -f`.
+
+### Known issue: remote MySQL connectivity
+
+When using the remote MySQL (`150.136.181.118`), the Hangfire server may experience **command timeout + SocketException 10060** in components like `ExpirationManager`. This is a network-level connectivity issue (not wait_timeout or connection pool). If it persists, deploy with the dedicated MySQL container approach (`docker-compose.yml`).
+
+## Namespace convention
+
+`PoliedroHangFire.{Layer}.{Subdomain}.{...}` — no separate assemblies per layer.

--- a/PoliedroHangFire/Infrastructure/External/Billing/Adapters/InvoicesEmitterBilling/InvoicesEmitterBilling.cs
+++ b/PoliedroHangFire/Infrastructure/External/Billing/Adapters/InvoicesEmitterBilling/InvoicesEmitterBilling.cs
@@ -17,7 +17,7 @@ public class InvoicesEmitterBilling(HttpClient httpClient, IConfiguration config
 
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
             var response = await httpClient.SendAsync(request, cts.Token);
 
             var responseContent = await response.Content.ReadAsStringAsync();

--- a/PoliedroHangFire/Infrastructure/External/Billing/Adapters/InvoicesEmitterBilling/InvoicesEmitterBilling.cs
+++ b/PoliedroHangFire/Infrastructure/External/Billing/Adapters/InvoicesEmitterBilling/InvoicesEmitterBilling.cs
@@ -7,19 +7,18 @@ public class InvoicesEmitterBilling(HttpClient httpClient, IConfiguration config
 {
     public async Task InvoicesEmitterServicesAsync(string jsonInvoices, string token)
     {
-        httpClient.DefaultRequestHeaders.Clear();
-        httpClient.DefaultRequestHeaders.Add("X-Environment", "production-billing");
         var request = new HttpRequestMessage(HttpMethod.Post, config["External:EmitInvoicesUrl"]);
+        request.Headers.Add("X-Environment", "production-billing");
         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
         request.Content = new StringContent(jsonInvoices, Encoding.UTF8, "application/json");
 
-        // Count request and measure duration
         metrics.BillingEmitRequestsTotal.Inc();
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
         try
         {
-            var response = await httpClient.SendAsync(request);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var response = await httpClient.SendAsync(request, cts.Token);
 
             var responseContent = await response.Content.ReadAsStringAsync();
 
@@ -28,21 +27,11 @@ public class InvoicesEmitterBilling(HttpClient httpClient, IConfiguration config
 
             response.EnsureSuccessStatusCode();
         }
-        catch (HttpRequestException ex)
-        {
-            // Increment error counter for failed emit requests
-            metrics.BillingEmitErrorsTotal.Inc();
-
-            Console.WriteLine("[ERROR] HttpRequestException al emitir facturas:");
-            Console.WriteLine($"[ERROR] {ex.Message}");
-        }
         catch (Exception ex)
         {
-            // Increment error counter for unexpected failures
             metrics.BillingEmitErrorsTotal.Inc();
-
-            Console.WriteLine("[ERROR] Excepción general al emitir facturas:");
-            Console.WriteLine($"[ERROR] {ex.Message}");
+            Console.WriteLine($"[ERROR] Error al emitir facturas: {ex.Message}");
+            throw;
         }
         finally
         {

--- a/PoliedroHangFire/Infrastructure/External/Billing/Adapters/PendingInvoicesBilling/PendingInvoicesService.cs
+++ b/PoliedroHangFire/Infrastructure/External/Billing/Adapters/PendingInvoicesBilling/PendingInvoicesService.cs
@@ -11,18 +11,15 @@ public class PendingInvoicesService(HttpClient httpClient, IConfiguration config
 {
     public async Task InvoicePendingAsync(int clienteId, string token, bool resolutionType, string name)
     {
-        // Mark job start and measure overall job duration
         metrics.BillingJobsExecutedTotal.Inc();
         var jobSw = System.Diagnostics.Stopwatch.StartNew();
 
         try
         {
-            // Each invocation corresponds to a client being processed by the orchestrator
             metrics.BillingClientsProcessedTotal.Inc();
 
-            httpClient.DefaultRequestHeaders.Add("X-Environment", "production-billing");
             var request = new HttpRequestMessage(HttpMethod.Get, config["External:PendingInvoicesUrl"]);
-
+            request.Headers.Add("X-Environment", "production-billing");
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             request.Content = new StringContent(JsonSerializer.Serialize(new
             {
@@ -30,9 +27,9 @@ public class PendingInvoicesService(HttpClient httpClient, IConfiguration config
                 Name = name
             }), Encoding.UTF8, "application/json");
 
-            // Measure time spent consulting pending invoices for this client
             var clientSw = System.Diagnostics.Stopwatch.StartNew();
-            var response = await httpClient.SendAsync(request);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var response = await httpClient.SendAsync(request, cts.Token);
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync();

--- a/PoliedroHangFire/Infrastructure/External/Billing/Adapters/PendingInvoicesBilling/PendingInvoicesService.cs
+++ b/PoliedroHangFire/Infrastructure/External/Billing/Adapters/PendingInvoicesBilling/PendingInvoicesService.cs
@@ -28,7 +28,7 @@ public class PendingInvoicesService(HttpClient httpClient, IConfiguration config
             }), Encoding.UTF8, "application/json");
 
             var clientSw = System.Diagnostics.Stopwatch.StartNew();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
             var response = await httpClient.SendAsync(request, cts.Token);
             response.EnsureSuccessStatusCode();
 

--- a/PoliedroHangFire/PoliedroHangFire.csproj
+++ b/PoliedroHangFire/PoliedroHangFire.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.8.22" />
 		<PackageReference Include="Hangfire.Core" Version="1.8.22" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1.1" />
-		<PackageReference Include="Hangfire.MySql.Core_MySql.Data" Version="2.1.10" />
+
 		<PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
 		<PackageReference Include="MySql.Data" Version="9.5.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/PoliedroHangFire/WebApi/HealthChecks/HangfireHealthCheck.cs
+++ b/PoliedroHangFire/WebApi/HealthChecks/HangfireHealthCheck.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using MySql.Data.MySqlClient;
+
+namespace PoliedroHangFire.WebApi.HealthChecks;
+
+public class HangfireHealthCheck : IHealthCheck
+{
+    private readonly string _connectionString;
+
+    public HangfireHealthCheck(IConfiguration configuration)
+    {
+        _connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION")
+            ?? configuration.GetConnectionString("HangfireConnection")
+            ?? throw new InvalidOperationException("MySQL connection string not found");
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var connection = new MySqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            using var command = new MySqlCommand(
+                "SELECT COUNT(*) FROM HangfireServer WHERE LastHeartbeat >= DATE_SUB(NOW(), INTERVAL 2 MINUTE)",
+                connection);
+            var activeServers = (long)(await command.ExecuteScalarAsync(cancellationToken))!;
+
+            if (activeServers > 0)
+            {
+                return HealthCheckResult.Healthy($"Hangfire server active. Servers: {activeServers}");
+            }
+
+            return HealthCheckResult.Unhealthy("No active Hangfire servers. Last heartbeat > 2 min.");
+        }
+        catch (MySqlException ex)
+        {
+            return HealthCheckResult.Unhealthy("MySQL connection failed for Hangfire", ex);
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Hangfire health check failed", ex);
+        }
+    }
+}

--- a/PoliedroHangFire/WebApi/Program.cs
+++ b/PoliedroHangFire/WebApi/Program.cs
@@ -15,17 +15,18 @@ var builder = WebApplication.CreateBuilder(args);
 
 
 builder.Services.AddHttpClient<IClientService, ClientService>();
-builder.Services.AddTransient<IPendingInvoicesBilling, PendingInvoicesService>();
-builder.Services.AddTransient<IInvoicesEmitterBIlling, InvoicesEmitterBilling>();
+builder.Services.AddHttpClient<IPendingInvoicesBilling, PendingInvoicesService>();
+builder.Services.AddHttpClient<IInvoicesEmitterBIlling, InvoicesEmitterBilling>();
 
 // Observability: prometheus-net metrics registration (centralized HangfireMetrics)
 builder.Services.AddSingleton<PoliedroHangFire.Infrastructure.Observability.HangfireMetrics>();
 
-// Agregar Health Check solo para el servicio de clientes
+// Health checks: servicio externo + Hangfire
 builder.Services.AddHealthChecks()
     .AddTypeActivatedCheck<ExternalServiceHealthCheck>(
         "client-service",
-        args: new object[] { builder.Configuration["External:ClientsUrl"]!, "Client Service" });
+        args: new object[] { builder.Configuration["External:ClientsUrl"]!, "Client Service" })
+    .AddCheck<HangfireHealthCheck>("hangfire");
 
 // Registrar HttpClient para health checks
 builder.Services.AddHttpClient();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: hangfire-mysql
+    environment:
+      MYSQL_DATABASE: hangfire
+      MYSQL_USER: hangfire
+      MYSQL_PASSWORD: hangfire_secret
+      MYSQL_ROOT_PASSWORD: root_secret
+    volumes:
+      - hangfire-mysql-data:/var/lib/mysql
+    ports:
+      - "3307:3306"
+    command:
+      - --innodb_buffer_pool_size=256M
+      - --max_connections=300
+      - --wait_timeout=28800
+      - --interactive_timeout=28800
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot_secret"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  hangfire:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: hangfire-app
+    ports:
+      - "8080:8080"
+    environment:
+      MYSQL_CONNECTION: "Server=mysql;Port=3306;Database=hangfire;Uid=hangfire;Pwd=hangfire_secret;Allow User Variables=True;Pooling=True;Max Pool Size=200;Connection Lifetime=300;Connection Idle Timeout=60;Connection Timeout=5;Default Command Timeout=60;"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  hangfire-mysql-data:


### PR DESCRIPTION
- Add Docker deployment for dedicated MySQL storage
- Configure Hangfire to use local MySQL container
- Add Hangfire health check
- Fix HangfireServer table lookup in health check
- Configure HttpClient through IHttpClientFactory
- Improve timeout handling and retry behavior

## Summary by Sourcery

Set up dedicated MySQL-backed Hangfire storage with local Docker compose support and improved observability and resilience.

New Features:
- Add a Hangfire-specific MySQL health check to the application health endpoints.
- Introduce a Docker Compose setup running a local MySQL instance and the Hangfire service for development.

Enhancements:
- Document project architecture, Hangfire configuration, external APIs, metrics, CI/CD, and local Docker usage in AGENTS.md.
- Configure Hangfire HTTP-dependent services via typed HttpClient registrations using IHttpClientFactory.
- Tighten HTTP timeout handling for pending invoices and invoice emission calls, and ensure errors are surfaced rather than silently swallowed.

CI:
- Clarify existing GitHub Actions workflow behavior and triggers in AGENTS.md.

Deployment:
- Describe ECS-based deployment workflow and container health checks in AGENTS.md.
- Provide a local Docker Compose environment with a dedicated MySQL container tuned for Hangfire workloads.

Documentation:
- Rewrite AGENTS.md to describe architecture, runtime behavior, endpoints, metrics, CI/CD, Docker usage, and known MySQL connectivity issues.

Chores:
- Check in IDE configuration files under .idea for the PoliedroHangFire project.